### PR TITLE
Mejoras en actualización de estado y envío de correos en CetelemPayment

### DIFF
--- a/cetelempayment.php
+++ b/cetelempayment.php
@@ -1390,17 +1390,30 @@ class CetelemPayment extends PaymentModule
 
     public function hookActionOrderStatusPostUpdate($params)
     {
+        $id_order = 0;
+        if (isset($params['id_order'])) {
+            $id_order = (int)$params['id_order'];
+        } elseif (isset($params['order']) && Validate::isLoadedObject($params['order'])) {
+            $id_order = (int)$params['order']->id;
+        }
+
         $order_state = isset($params['newOrderStatus']) ? $params['newOrderStatus'] : $params['orderStatus'];
         switch ($order_state->id) {
             case $this->cetelemStates->StateCetelemPreApproved():
                 $this->addPayment($params);
-                $this->sendCetelemEmail('cetelem_preapproved_credit', $params['id_order'], $params['newOrderStatus']);
+                if ($id_order) {
+                    $this->sendCetelemEmail('cetelem_preapproved_credit', $id_order, $params['newOrderStatus']);
+                }
                 break;
             case $this->cetelemStates->StateCetelemApproved():
-                $this->sendCetelemEmail('cetelem_credit_ok', $params['id_order'], $params['newOrderStatus']);
+                if ($id_order) {
+                    $this->sendCetelemEmail('cetelem_credit_ok', $id_order, $params['newOrderStatus']);
+                }
                 break;
             case $this->cetelemStates->StateCetelemDenied():
-                $this->sendCetelemEmail('cetelem_credit_ko', $params['id_order'], $params['newOrderStatus']);
+                if ($id_order) {
+                    $this->sendCetelemEmail('cetelem_credit_ko', $id_order, $params['newOrderStatus']);
+                }
                 /* To restore the quantity of each product and / or combination */
                 //(discommented again) we commented that on 2.5.0 version because we do it already in the overrides (check and get sure, otherwise we may be have to uncomment this again)
                 /*$order = new Order($params['id_order']);

--- a/controllers/front/callback.php
+++ b/controllers/front/callback.php
@@ -391,11 +391,17 @@ class CetelemPaymentCallbackModuleFrontController extends ModuleFrontController
             $this->writeToDebug('updateOrderState set new_state');
             $this->writeToDebug("updateOrderState newState == " . print_r($new_state, true));
 
-            $order->setCurrentState($new_state);
+            $this->writeToDebug('updateOrderState: Attempting OrderHistory update without email');
+            $history = new OrderHistory();
+            $history->id_order = (int)$order->id;
+            $history->id_order_state = (int)$new_state;
+            $history->change_log = true; // Para que se registre el cambio
+            $history->add(true); // El parámetro 'true' evita el envío de correo electrónico
 
-            $this->writeToDebug("Order state updated: Order ID {$order->id} -> State {$new_state}");
-            $this->writeToDebug('updateOrderState save()');
-            $order->save();
+            $this->writeToDebug("Order state updated: Order ID {$order->id} -> State {$new_state} (No Email)");
+            $this->writeToDebug('updateOrderState: Order state updated via OrderHistory.');
+            // $order->save() no es necesario si solo se actualiza el estado con OrderHistory::add()
+
 
         } catch (Exception $e) {
             $this->writeToDebug('updateOrderState ERRCatch');


### PR DESCRIPTION
- Validación del id_order en hookActionOrderStatusPostUpdate()
- Sustitución de setCurrentState() por OrderHistory::add() para evitar envío de email
- Nuevos logs de depuración para mayor trazabilidad